### PR TITLE
load stats after table loads

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -50,7 +50,7 @@ github = new Octokat
 
 main = ->
   loadMatrix()
-  loadStats()
+  .then => loadStats()
 
 loadMatrix = ->
   github.orgs('ipfs').repos.fetch(per_page: 100)


### PR DESCRIPTION
currently it looks strange when the stats line loads alone, then the table loads... looks a bit broken.  with this change we load stats after the table loads, looks better.
