### PR TITLE
Fixed badge check

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -32,8 +32,8 @@ RAW_GITHUB_SOURCES = [
 ]
 
 README_BADGES =
-  'Travis': (repoName) -> "](https://travis-ci.org/#{ORG}/#{repoName}.svg?branch=master)](https://travis-ci.org/#{ORG}/#{repoName})"
-  'Circle': (repoName) -> "](https://circleci.com/gh/#{ORG}/#{repoName}.svg?style=svg)](https://circleci.com/gh/#{ORG}/#{repoName})"
+  'Travis': (repoName) -> "(https://travis-ci.org/#{ORG}/#{repoName})"
+  'Circle': (repoName) -> "(https://circleci.com/gh/#{ORG}/#{repoName})"
   'Made By': -> '[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)'
   'Project': -> '[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)'
   'IRC':     -> '[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)'


### PR DESCRIPTION
We only really need to check for the link, not for the full markdown. Some repos are displaying this differently - for instance:

ipfs/station:

```
   [![Build Status](https://img.shields.io/travis/ipfs/station/master.svg?style=flat-square)](https://travis-ci.org/ipfs/station)
```

ipfs/js-ipfs:

```
 [![Travis CI](https://travis-ci.org/ipfs/js-ipfs.svg?branch=master)](https://travis-ci.org/ipfs/js-ipfs)
```

Both should be caught. This commit allows this possibility, and we see more coverage on the project-repos board.

Related to #32.
