### PR TITLE
Add link to circleci settings

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -168,7 +168,7 @@ travis = renderable (repoName) ->
 
 circle = renderable (repoName) ->
   a href: "https://circleci.com/gh/#{ORG}/#{repoName}", ->
-    img src: "https://circleci.com/gh/#{ORG}/#{repoName}.svg?style=svg", onError: "this.src = 'images/circle-ci-no-builds.svg'"
+    img src: "https://circleci.com/gh/#{ORG}/#{repoName}.svg?style=svg", onError: "this.parentElement.href = 'https://circleci.com/add-projects'; this.src = 'images/circle-ci-no-builds.svg'"
 
 loadStats = ->
   github.rateLimit.fetch()


### PR DESCRIPTION
When a repository does not have circleci enabled, we notice and set a different badge using the image onError feature. We can also link directly to the circleci settings, where you can enable it easiest. For travis, this is already done, too; this is as close as we can get, I think, to automatically enabling from clicking on the badge, and I think all we need, as this is a one-off for each repository (the number of which is, in fact, finite).

Closes #62
