### PR TITLE
Make ToC and Install and Usage conditional

### DIFF
--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -4,6 +4,12 @@
   line-height: 2em;
 }
 
+.na {
+  background-color: white;
+  color: grey;
+  line-height: 2em;
+}
+
 .failure {
   line-height: 2em;
   background-color: darkred;

--- a/src/RepoMatrix.coffee
+++ b/src/RepoMatrix.coffee
@@ -76,6 +76,7 @@ class RepoMatrix
     'License': -> '## License'
 
   README_OTHER =
+    'TODO': -> 'TODO'
     'Banner': -> '![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)'
 
   README_ITEMS = merge README_SECTIONS, README_OTHER
@@ -211,8 +212,9 @@ class RepoMatrix
                   td class: 'no-padding', => @check('na')
                 else
                   td class: 'no-padding', => @check(repo.files[README]?.indexOf(expectedMarkdown) >= 0)
+              else if name == 'TODO'
+                td class: 'no-padding', => @check(repo.files[README]?.indexOf(expectedMarkdown) == -1)
               else
-                console.log name, template
                 td class: 'no-padding', => @check(repo.files[README]?.indexOf(expectedMarkdown) >= 0)
             for name, template of README_BADGES
               expectedMarkdown = template repo.fullName

--- a/src/RepoMatrix.coffee
+++ b/src/RepoMatrix.coffee
@@ -201,7 +201,19 @@ class RepoMatrix
             td class: 'no-padding', => @check repo.files[CONTRIBUTE]                                 # Files
             for name, template of README_ITEMS                                                       # Badges
               expectedMarkdown = template repo.fullName
-              td class: 'no-padding', => @check(repo.files[README]?.indexOf(expectedMarkdown) >= 0)
+              if name == 'ToC'
+                if repo.files[README]?.split('\n').length < 100
+                  td class: 'no-padding', => @check('na')
+                else
+                  td class: 'no-padding', => @check(repo.files[README]?.indexOf(expectedMarkdown) >= 0)
+              else if name == 'Install' || name == 'Usage'
+                if repo.files[README]?.match('This repository is (only for documents|a \\*\\*work in progress\\*\\*)\\.')
+                  td class: 'no-padding', => @check('na')
+                else
+                  td class: 'no-padding', => @check(repo.files[README]?.indexOf(expectedMarkdown) >= 0)
+              else
+                console.log name, template
+                td class: 'no-padding', => @check(repo.files[README]?.indexOf(expectedMarkdown) >= 0)
             for name, template of README_BADGES
               expectedMarkdown = template repo.fullName
               td class: 'no-padding', => @check(repo.files[README]?.indexOf(expectedMarkdown) >= 0)
@@ -209,7 +221,9 @@ class RepoMatrix
             td => repo.openIssuesCount.toString()
 
   @check: renderable (success) ->
-    if success
+    if success == 'na'
+      div class: 'na', -> '-'
+    else if success
       div class: 'success', -> '✓'
     else
       div class: 'failure', -> '✗'


### PR DESCRIPTION
ToC should only be checked if there are 100 lines or more, and install and usage shouldnt be there if it is a document repo. Added checks for these, and made an empry block.